### PR TITLE
Add missing sections of the tool model

### DIFF
--- a/mcp-model/src/main/java/org/mcp_java/model/tool/CallToolRequest.java
+++ b/mcp-model/src/main/java/org/mcp_java/model/tool/CallToolRequest.java
@@ -17,16 +17,21 @@ package org.mcp_java.model.tool;
 
 import java.util.Map;
 
+import org.mcp_java.model.common.MetaKey;
+
 /**
  * Request to call a tool.
  *
  * @param name      the name of the tool to call
  * @param arguments the arguments to pass to the tool (optional)
+ * @param _meta     additional metadata sent with the call tool request
  * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/server/tools#calling-tools">MCP Specification - Calling Tools</a>
+ * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/schema#calltoolrequest">MCP Schema Reference - CallToolRequest</a>
  */
 public record CallToolRequest(
     String name,
-    Map<String, Object> arguments
+    Map<String, Object> arguments,
+    Map<MetaKey, Object> _meta
 ) {
 
     /**
@@ -46,7 +51,7 @@ public record CallToolRequest(
      * @return new request
      */
     public static CallToolRequest of(String name, Map<String, Object> arguments) {
-        return new CallToolRequest(name, arguments);
+        return new CallToolRequest(name, arguments, null);
     }
 
     /**
@@ -56,6 +61,6 @@ public record CallToolRequest(
      * @return new request
      */
     public static CallToolRequest of(String name) {
-        return new CallToolRequest(name, null);
+        return new CallToolRequest(name, null, null);
     }
 }

--- a/mcp-model/src/main/java/org/mcp_java/model/tool/CallToolResult.java
+++ b/mcp-model/src/main/java/org/mcp_java/model/tool/CallToolResult.java
@@ -15,19 +15,26 @@
  */
 package org.mcp_java.model.tool;
 
+import org.mcp_java.model.common.MetaKey;
 import org.mcp_java.model.content.ContentBlock;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Result of calling a tool.
  *
  * @param content the result content blocks
+ * @param structuredContent the structured content of the tool result
  * @param isError whether the tool call resulted in an error
+ * @param _meta additional metadata sent with the tool result
  * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/server/tools#calling-tools">MCP Specification - Calling Tools</a>
+ * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/schema#calltoolresult">MCP Schema Reference - CallToolResult</a>
  */
 public record CallToolResult(
     List<ContentBlock> content,
-    Boolean isError
+    Object structuredContent,
+    Boolean isError,
+    Map<MetaKey, Object> _meta
 ) {
 
     /**
@@ -46,9 +53,19 @@ public record CallToolResult(
      * @return a new success result
      */
     public static CallToolResult success(List<ContentBlock> content) {
-        return new CallToolResult(content, false);
+        return new CallToolResult(content, null, false, null);
     }
 
+    /**
+     * Creates a successful tool result with structured content
+     * 
+     * @param structuredContent the structured content
+     * @return a new success result
+     */
+    public static CallToolResult structuredSuccess(Object structuredContent) {
+    	return new CallToolResult(null, structuredContent, false, null);
+    }
+    
     /**
      * Creates an error tool result.
      *
@@ -56,6 +73,6 @@ public record CallToolResult(
      * @return a new error result
      */
     public static CallToolResult error(List<ContentBlock> content) {
-        return new CallToolResult(content, true);
+        return new CallToolResult(content, null, true, null);
     }
 }

--- a/mcp-model/src/main/java/org/mcp_java/model/tool/ListToolsRequest.java
+++ b/mcp-model/src/main/java/org/mcp_java/model/tool/ListToolsRequest.java
@@ -22,6 +22,7 @@ import org.mcp_java.model.common.Cursor;
  *
  * @param cursor optional cursor for pagination
  * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/server/tools#listing-tools">MCP Specification - Listing Tools</a>
+ * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/schema#listtoolsrequest">MCP Schema Reference - ListToolsRequest</a>
  */
 public record ListToolsRequest(
     Cursor cursor

--- a/mcp-model/src/main/java/org/mcp_java/model/tool/ListToolsResult.java
+++ b/mcp-model/src/main/java/org/mcp_java/model/tool/ListToolsResult.java
@@ -24,6 +24,7 @@ import java.util.List;
  * @param tools      the list of available tools
  * @param nextCursor optional cursor for pagination
  * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/server/tools#listing-tools">MCP Specification - Listing Tools</a>
+ * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/schema#listtoolsresult">MCP Schema Reference - ListToolsResult</a>
  */
 public record ListToolsResult(
     List<Tool> tools,

--- a/mcp-model/src/main/java/org/mcp_java/model/tool/Tool.java
+++ b/mcp-model/src/main/java/org/mcp_java/model/tool/Tool.java
@@ -17,18 +17,29 @@ package org.mcp_java.model.tool;
 
 import java.util.Map;
 
+import org.mcp_java.model.common.MetaKey;
+
 /**
  * A tool that can be invoked by the client.
  *
  * @param name        the unique name of the tool
- * @param description a human-readable description of what the tool does
+ * @param title       optional human-readable name for the tool
+ * @param description optional human-readable description of what the tool does
  * @param inputSchema JSON Schema for the tool's parameters
+ * @param outputSchema JSON Schema for the structured content part of the tool's output. {@code null} if the tool does not output structured content.
+ * @param annotations optional additional information about the tool
+ * @param _meta       optional additional metadata attached to this tool
  * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool">MCP Specification - Tool</a>
+ * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/schema#tool">MCP Schema Reference - Tool</a>
  */
 public record Tool(
     String name,
+    String title,
     String description,
-    Map<String, Object> inputSchema
+    Object inputSchema,
+    Object outputSchema,
+    ToolAnnotations annotations,
+    Map<MetaKey, Object> _meta
 ) {
 
     /**
@@ -52,7 +63,7 @@ public record Tool(
      * @return a new tool
      */
     public static Tool of(String name, String description, Map<String, Object> inputSchema) {
-        return new Tool(name, description, inputSchema);
+        return new Tool(name, null, description, inputSchema, null, null, null);
     }
 
     /**
@@ -63,6 +74,6 @@ public record Tool(
      * @return a new tool
      */
     public static Tool of(String name, Map<String, Object> inputSchema) {
-        return new Tool(name, null, inputSchema);
+        return new Tool(name, null, null, inputSchema, null, null, null);
     }
 }

--- a/mcp-model/src/main/java/org/mcp_java/model/tool/ToolAnnotations.java
+++ b/mcp-model/src/main/java/org/mcp_java/model/tool/ToolAnnotations.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mcp_java.model.tool;
+
+/**
+ * Additional information about the properties of a tool, provided as hints for clients.
+ * 
+ * @param title optional human-readable name for the tool
+ * @param readOnlyHint {@code true} if the tool does not modify its environment, {@code false} otherwise. Assumed {@code false} if not set.
+ * @param destructiveHint {@code true} if the code may perform destructive updates, {@code false otherwise}. Assumed {@code true} if not set.
+ * @param idempotentHint {@code true} if calling the tool twice with the same arguments will not have additional effects on its environment, {@code false} otherwise. Assumed {@code false} if not set.
+ * @param openWorldHint {@code true} if the tool may interact with an "open world" of external entities, {@code false} otherwise. Assumed {@code true} if not set.
+ * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/schema#toolannotations">MCP Schema Reference - ToolAnnotations</a>
+ */
+public record ToolAnnotations(
+		String title,
+		Boolean readOnlyHint,
+		Boolean destructiveHint,
+		Boolean idempotentHint,
+		Boolean openWorldHint) {
+}


### PR DESCRIPTION
Fixes #1 

- I've only looked at tools, I'd guess there are similar issues in other areas
- I've included `_meta` fields as `Map<MetaKey, Object>`. That's slightly different to `Meta.asMap` which returns `Map<String, Object>`, possibly those should be aligned.