### PR TITLE
Add `Icons` annotation and `IconProvider`

### DIFF
--- a/mcp-server-api/src/main/java/org/mcp_java/server/FeatureType.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/FeatureType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mcp_java.server;
+
+import org.mcp_java.server.prompts.Prompt;
+import org.mcp_java.server.resources.Resource;
+import org.mcp_java.server.resources.ResourceTemplate;
+import org.mcp_java.server.tools.Tool;
+
+/**
+ * The types of features that an MCP server implemented with this API can provide.
+ */
+public enum FeatureType {
+
+    /**
+     * A {@link Prompt}
+     */
+    PROMPT,
+    /**
+     * A {@link Resource}
+     */
+    RESOURCE,
+    /**
+     * A {@link ResourceTemplate}
+     */
+    RESOURCE_TEMPLATE,
+    /**
+     * A {@link Tool}
+     */
+    TOOL
+}

--- a/mcp-server-api/src/main/java/org/mcp_java/server/Icon.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/Icon.java
@@ -15,6 +15,8 @@
  */
 package org.mcp_java.server;
 
+import static org.mcp_java.server.spi.McpServerSPILoader.getSPI;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -54,14 +56,84 @@ public interface Icon {
     /**
      * The theme for an icon
      */
-    public enum Theme {
+    enum Theme {
         /**
-         * Indicates this icon is appropriate for a light theme
+         * Indicates this icon is appropriate for use with a light background
          */
         LIGHT,
         /**
-         * Indicates this icon is appropriate for a dark theme
+         * Indicates this icon is appropriate for use with a dark background
          */
         DARK
+    }
+
+    /**
+     * Creates a new {@code Icon}.
+     * 
+     * @param uri the icon URI
+     * @param mimeType the icon MIME type
+     * @return the new icon
+     */
+    static Icon of(String uri, String mimeType) {
+        return getSPI().newIcon(uri, mimeType);
+    }
+
+    /**
+     * Creates a builder for an {@code Icon}.
+     * 
+     * @param uri the icon URI
+     * @return the new icon builder
+     */
+    static Icon.Builder builder(String uri) {
+        return getSPI().iconBuilder(uri);
+    }
+
+    /**
+     * Builder for creating icons.
+     */
+    interface Builder {
+
+        /**
+         * Sets the MIME type of the icon
+         * 
+         * @param mimeType the MIME type
+         * @return this builder
+         */
+        Builder setMimeType(String mimeType);
+
+        /**
+         * Adds a size that this icon can be displayed at.
+         * <p>
+         * May not be used with {@link #setAnySize()}.
+         * 
+         * @param width the width
+         * @param height the height
+         * @return this builder
+         */
+        Builder addSize(int width, int height);
+
+        /**
+         * Sets that the icon may be used at any size. Usually for scalable icons.
+         * <p>
+         * May not be used with {@link #addSize(int, int)}.
+         * 
+         * @return this builder
+         */
+        Builder setAnySize();
+
+        /**
+         * Sets the theme that this icon is designed for.
+         * 
+         * @param theme the theme
+         * @return this builder
+         */
+        Builder setTheme(Theme theme);
+
+        /**
+         * Builds the icon
+         * 
+         * @return the new icon
+         */
+        Icon build();
     }
 }

--- a/mcp-server-api/src/main/java/org/mcp_java/server/IconProvider.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/IconProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mcp_java.server;
+
+import java.util.List;
+
+/**
+ * Provides icons for a prompt, resource, or tool.
+ * <p>
+ * The lifecycle of an {@code IconProvider} is implementation-specific. For example,
+ * implementations may require an {@code IconProvider} to have a no-argument constructor,
+ * or may require integration with a component framework.
+ */
+public interface IconProvider {
+    
+    /**
+     * Returns a list of icons for an MCP server feature. The list may include various different
+     * icons for the same feature for display at different sizes or for different themes.
+     * 
+     * @param featureType the type of feature to retrieve icons for (e.g. prompt, tool etc.)
+     * @param name the name of the feature (i.e. the tool name, the prompt name etc.)
+     * @return the list of icons, which may be empty if no icons are available
+     */
+    List<Icon> getIcons(FeatureType featureType, String name);
+
+}

--- a/mcp-server-api/src/main/java/org/mcp_java/server/Icons.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/Icons.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mcp_java.server;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates an {@link IconProvider} which can provide icons for the annotated Tool, Resource, Resource
+ * Template or Prompt.
+ * <p>
+ * Note that the lifecycle of an {@code IconProvider} is implementation-specific. For example,
+ * implementations may require an {@code IconProvider} to have a no-argument constructor,
+ * or may require it to be looked up using a component framework.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({TYPE, METHOD})
+public @interface Icons {
+    
+    /**
+     * The icon provider to use to retrieve icons for the annotated element
+     * 
+     * @return the icon provider class
+     */
+    Class<? extends IconProvider> iconProvider();
+}

--- a/mcp-server-api/src/main/java/org/mcp_java/server/package-info.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/package-info.java
@@ -22,6 +22,7 @@
  * <li>{@link org.mcp_java.server.MetaField @MetaField} - Adds custom metadata fields to MCP definitions</li>
  * <li>{@link org.mcp_java.server.Cancellation} - Request cancellation handling</li>
  * <li>{@link org.mcp_java.server.ContentEncoder} - Custom content encoding</li>
+ * <li>{@link org.mcp_java.server.Icons @Icons} - Assigns icons to tools, resources and prompts</li>
  * <li>{@link org.mcp_java.server.McpException} - Base MCP exception</li>
  * <li>{@link org.mcp_java.server.McpConnection} - Connection metadata and status, including client capabilities</li>
  * <li>{@link org.mcp_java.server.McpLog} - Client-side logging</li>

--- a/mcp-server-api/src/main/java/org/mcp_java/server/spi/McpServerSPI.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/spi/McpServerSPI.java
@@ -19,6 +19,8 @@ package org.mcp_java.server.spi;
 import java.util.List;
 import java.util.ServiceLoader;
 
+import org.mcp_java.server.Icon;
+import org.mcp_java.server.Icon.Builder;
 import org.mcp_java.server.Role;
 import org.mcp_java.server.completion.CompletionResult;
 import org.mcp_java.server.content.Annotations;
@@ -350,6 +352,26 @@ public interface McpServerSPI {
         return toolResponseBuilder().setStructuredContent(structuredContent)
                                     .setError(false)
                                     .build();
+    }
+
+    /**
+     * Creates a builder for a new {@link Icon}
+     * 
+     * @param uri the icon URI
+     * @return the {@code Icon} builder
+     */
+    Builder iconBuilder(String uri);
+
+    /**
+     * Creates a new {@link Icon}
+     *
+     * @param uri the icon URI
+     * @param mimeType the icon MIME type
+     * @return the new {@code Icon}
+     */
+    default Icon newIcon(String uri, String mimeType) {
+        return iconBuilder(uri).setMimeType(mimeType)
+                               .build();
     }
 
 }


### PR DESCRIPTION
These provide a way to associate the necessary icon information with server features.

Add a builder and SPI for the `Icon` interface, now that they can be provided by the user.

Compared to the [quarkus interface](https://github.com/quarkiverse/quarkus-mcp-server/blob/main/core/runtime/src/main/java/io/quarkiverse/mcp/server/IconsProvider.java), I'm passing in an enum to indicate the type and the name, since we don't have anything like `FeatureInfo` in the API.

Fixes #24 
@mkouba