### PR TITLE
Define annotated method parameters

### DIFF
--- a/mcp-server-api/src/main/java/org/mcp_java/server/completion/CompletePrompt.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/completion/CompletePrompt.java
@@ -21,31 +21,46 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.mcp_java.server.Cancellation;
+import org.mcp_java.server.McpConnection;
+import org.mcp_java.server.progress.Progress;
 import org.mcp_java.server.prompts.Prompt;
 
 /**
  * Marks a method as providing completion suggestions for a prompt argument.
  * <p>
  * The annotated method returns completion values for a specific prompt argument.
+ * 
+ * <h2>Parameters</h2>
  * <p>
- * The method must consume exactly one {@link String} argument representing the
- * partial value that needs to be completed.
- * <p>
- * The method may consume a {@link CompletionContext} argument to access values
- * already chosen for other arguments.
+ * Prompt completion methods may have parameters of the following types:
+ * <ul>
+ * <li>{@link String} - the method must have exactly one {@code String} parameter representing
+ * the partial value that needs to be completed. In most cases it must be annotated with {@link CompleteArg}
+ * with the {@link CompleteArg#name() name} attribute set, unless the code was compiled with the
+ * {@code -parameters} option. The name must match the name of one of the arguments of the related prompt.
+ * <li>{@link CompletionContext} - to access values already chosen for other arguments
+ * <li>{@link McpConnection} - to access information about the MCP connection
+ * <li>{@link Cancellation} - to allow processing to be stopped if the client cancels the tool call
+ * <li>{@link Progress} - to send progress reports back to the client
+ * <li>Implementations may define additional types that can be used as parameters
+ * </ul>
+ * 
+ * <h2>Return Type Handling</h2>
  * <p>
  * Return types can be:
  * <ul>
  * <li>{@code String} - single completion value</li>
  * <li>{@code List<String>} - multiple completion values</li>
  * <li>{@link CompletionResult} - full completion response with metadata</li>
+ * <li>Other types - Encoded according to framework-specific rules</li>
  * </ul>
  * <p>
  * Example:
  * </p>
  * <pre>
  * &#64;CompletePrompt("myPrompt")
- * public List&lt;String&gt; completeMyPromptArg(&#64;CompleteArg String partialValue) {
+ * public List&lt;String&gt; completeMyPromptArg(&#64;CompleteArg(name = "value") String partialValue) {
  *     return List.of("option1", "option2", "option3");
  * }
  * </pre>

--- a/mcp-server-api/src/main/java/org/mcp_java/server/completion/CompleteResourceTemplate.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/completion/CompleteResourceTemplate.java
@@ -21,16 +21,32 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.mcp_java.server.Cancellation;
+import org.mcp_java.server.McpConnection;
+import org.mcp_java.server.progress.Progress;
+import org.mcp_java.server.resources.ResourceTemplate;
+
 /**
  * Marks a method as providing completion suggestions for a resource template URI expression.
  * <p>
  * The annotated method returns completion values for URI template variables.
+ * 
+ * <h2>Parameters</h2>
  * <p>
- * The method must consume exactly one {@link String} argument representing the
- * partial value that needs to be completed.
- * <p>
- * The method may consume a {@link CompletionContext} argument to access values
- * already chosen for other arguments.
+ * Resource template completion methods may have parameters of the following types:
+ * <ul>
+ * <li>{@link String} - the method must have exactly one {@code String} parameter representing
+ * the partial value that needs to be completed. In most cases it must be annotated with {@link CompleteArg}
+ * with the {@link CompleteArg#name() name} attribute set, unless the code was compiled with the
+ * {@code -parameters} option. The name must match the name of one of the arguments of the related resource template.
+ * <li>{@link CompletionContext} - to access values already chosen for other arguments
+ * <li>{@link McpConnection} - to access information about the MCP connection
+ * <li>{@link Cancellation} - to allow processing to be stopped if the client cancels the tool call
+ * <li>{@link Progress} - to send progress reports back to the client
+ * <li>Implementations may define additional types that can be used as parameters
+ * </ul>
+ * 
+ * <h2>Return Type Handling</h2>
  * <p>
  * Return types can be:
  * </p>
@@ -38,13 +54,14 @@ import java.lang.annotation.Target;
  * <li>{@code String} - single completion value</li>
  * <li>{@code List<String>} - multiple completion values</li>
  * <li>{@link CompletionResult} - full completion response with metadata</li>
+ * <li>Other types - Encoded according to framework-specific rules</li>
  * </ul>
  * <p>
  * Example:
  * </p>
  * <pre>
  * &#64;CompleteResourceTemplate("fileTemplate")
- * public List&lt;String&gt; completeFilePath(&#64;CompleteArg String partialPath) {
+ * public List&lt;String&gt; completeFilePath(&#64;CompleteArg(name = "path") String partialPath) {
  *     // Return matching file paths
  *     return findMatchingPaths(partialPath);
  * }
@@ -58,7 +75,7 @@ public @interface CompleteResourceTemplate {
     /**
      * The name of the resource template this completion method is for.
      * <p>
-     * This must reference an existing {@code @ResourceTemplate} annotation's name.
+     * This must reference an existing {@link ResourceTemplate @ResourceTemplate} annotation's name.
      * </p>
      *
      * @return the resource template name

--- a/mcp-server-api/src/main/java/org/mcp_java/server/prompts/Prompt.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/prompts/Prompt.java
@@ -21,10 +21,29 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.mcp_java.server.Cancellation;
+import org.mcp_java.server.McpConnection;
+import org.mcp_java.server.progress.Progress;
+
 /**
  * Marks a method as providing an MCP prompt template.
- * <p>
  * Prompts are reusable message templates that can be used by MCP clients.
+ * 
+ * <h2>Parameters</h2>
+ * Prompt methods may have parameters of the following types:
+ * <ul>
+ * <li>{@link String} - each {@code String} parameter is treated as an argument to the prompt.
+ * In most cases these parameters must be annotated with {@link PromptArg} with the {@link PromptArg#name() name}
+ * attribute set, unless the code was compiled with the {@code -parameters} option.
+ * {@code PromptArg} also allows other properties of the argument to be configured.
+ * <li>{@link McpConnection} - to access information about the MCP connection
+ * <li>{@link Cancellation} - to allow processing to be stopped if the client cancels the prompt request
+ * <li>{@link Progress} - to send progress reports back to the client
+ * <li>Implementations may define additional types that can be used as parameters
+ * </ul>
+ * 
+ * <h2>Return Type Handling</h2>
+ * <p>
  * The annotated method can return various types that will be converted to prompt responses:
  * </p>
  * <ul>
@@ -33,10 +52,6 @@ import java.lang.annotation.Target;
  * <li>{@link PromptResponse} - Full response with description and messages</li>
  * <li>Other types - Encoded according to framework-specific rules</li>
  * </ul>
- * <p>
- * Method parameters can be configured using {@link PromptArg} annotations to define
- * the prompt's argument schema.
- * </p>
  *
  * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/server/prompts">MCP Specification - Prompts</a>
  * @see PromptArg

--- a/mcp-server-api/src/main/java/org/mcp_java/server/resources/Resource.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/resources/Resource.java
@@ -21,10 +21,25 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.mcp_java.server.Cancellation;
+import org.mcp_java.server.McpConnection;
 import org.mcp_java.server.Role;
+import org.mcp_java.server.progress.Progress;
 
 /**
  * Marks a method as providing an MCP resource.
+ * 
+ * <h2>Parameters</h2>
+ * <p>
+ * Resource methods may have parameters of the following types:
+ * <ul>
+ * <li>{@link McpConnection} - to access information about the MCP connection
+ * <li>{@link Cancellation} - to allow processing to be stopped if the client cancels the resource fetch request
+ * <li>{@link Progress} - to send progress reports back to the client
+ * <li>Implementations may define additional types that can be used as parameters
+ * </ul>
+ * 
+ * <h2>Return Type Handling</h2>
  * <p>
  * The result of a "resource read" operation is represented as a resource response.
  * The annotated method can return various types that will be converted according to

--- a/mcp-server-api/src/main/java/org/mcp_java/server/resources/ResourceTemplate.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/resources/ResourceTemplate.java
@@ -21,10 +21,29 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.mcp_java.server.Cancellation;
+import org.mcp_java.server.McpConnection;
 import org.mcp_java.server.Role;
+import org.mcp_java.server.progress.Progress;
 
 /**
  * Marks a method as providing dynamic MCP resources via URI templates.
+ * 
+ * <h2>Parameters</h2>
+ * <p>
+ * Resource template methods may have parameters of the following types:
+ * <ul>
+ * <li>{@link String} - the method must have one {@code String} parameter for each variable in the {@link #uriTemplate uriTemplate}.
+ * In most cases these parameters must be annotated with{@link ResourceTemplateArg} with the {@link ResourceTemplateArg#name() name}
+ * attribute set, unless the code was compiled with the {@code -parameters} option.
+ * {@code ResourceTemplateArg} also allows other properties of the argument to be configured.
+ * <li>{@link McpConnection} - to access information about the MCP connection
+ * <li>{@link Cancellation} - to allow processing to be stopped if the client cancels the tool call
+ * <li>{@link Progress} - to send progress reports back to the client
+ * <li>Implementations may define additional types that can be used as parameters
+ * </ul>
+ * 
+ * <h2>Return Type Handling</h2>
  * <p>
  * The result of a "resource read" operation is represented as a resource response.
  * The annotated method can return various types that will be converted according to

--- a/mcp-server-api/src/main/java/org/mcp_java/server/tools/Tool.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/tools/Tool.java
@@ -21,7 +21,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.mcp_java.server.Cancellation;
+import org.mcp_java.server.McpConnection;
 import org.mcp_java.server.content.ContentBlock;
+import org.mcp_java.server.progress.Progress;
 
 /**
  * Marks a method as an MCP tool that can be invoked by clients.
@@ -30,9 +33,21 @@ import org.mcp_java.server.content.ContentBlock;
  * explicitly specified via the {@link #name()} attribute, or will be derived from
  * the method name if not specified.
  * </p>
+ * 
+ * <h2>Parameters</h2>
  * <p>
- * Method parameters can be further configured using {@link ToolArg} annotations.
- * </p>
+ * Tool methods may have parameters of the following types:
+ * <ul>
+ * <li>{@link McpConnection} - to access information about the MCP connection
+ * <li>{@link Cancellation} - to allow processing to be stopped if the client cancels the tool call
+ * <li>{@link Progress} - to send progress reports back to the client
+ * <li>Implementations may define additional types that can be used as parameters
+ * <li><strong>All other parameters</strong> are treated as arguments to the tool.
+ * In most cases these parameters must be annotated with {@link ToolArg} with the
+ * {@link ToolArg#name() name} attribute set, unless the code was compiled with the
+ * {@code -parameters} option.
+ * {@code ToolArg} also allows other properties of the argument to be configured.
+ * </ul>
  *
  * <h2>Return Type Handling</h2>
  * <p>


### PR DESCRIPTION
Document the supported parameters for tool, resource, prompt and completion methods.

- Clarify that the `@FooArg` annotation is not actually required, but usually needed to provide the name
- Document that `McpConnection` and `Cancellation` can be accepted as arguments by all methods
- Document that resource template arguments must have a corresponding variable in the uriTemplate
- Document that resource template completion argument names must match the name of a resource template argument
- Document that prompt completion arguments names must match the name of a prompt argument
- Update examples which used `CompleteArg` with no attributes
- Allow implementations to support additional return types for `@CompletePrompt` and `@CompleteResourceTemplate`

`Meta` should be added to all methods if #45 is merged.

`RequestId` should be added to all methods if created for #47

Fixes #40