### PR TITLE
Add RequestId interface

### DIFF
--- a/mcp-server-api/src/main/java/org/mcp_java/server/RequestId.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/RequestId.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mcp_java.server;
+
+/**
+ * The ID of an MCP request. The ID of a request can be either a number or a string.
+ * <p>
+ * Tool, Prompt, Resource, and ResourceTemplate methods can accept this interface as a parameter.
+ * It will be automatically injected by the framework implementation before the method is invoked.
+ * </p>
+ */
+public interface RequestId {
+
+    /**
+     * The value of the RequestID, either a {@link String} or a {@link Number}.
+     * <p>
+     * The {@code value} of two RequestIDs must be equal if and only if the JSON values they were created from were equal.
+     * 
+     * @return the value of the RequestID
+     */
+    Object value();
+
+    /**
+     * Returns a string representation of the RequestId.
+     * <p>
+     * If the value is a {@code String}, this method returns the string in quotes (").
+     * <p>
+     * If the value is a {@code Number}, this method returns a string representation of the number.
+     * 
+     * @return the RequestId as a string
+     */
+    @Override
+    String toString();
+
+    /**
+     * Two requestIds are equal if their values are equal and are either both numbers or both strings.
+     * 
+     * @param other the object with which to compare
+     * @return {@code true} if {@code other} is a {@code RequestId} and its value is equal to the value
+     * of this object, otherwise {@code false}
+     */
+    @Override
+    boolean equals(Object other);
+
+    /**
+     * The hash code of a requestId is the hash code of its value.
+     * 
+     * @return the hash code of the requestId
+     */
+    @Override
+    int hashCode();
+}

--- a/mcp-server-api/src/main/java/org/mcp_java/server/completion/CompletePrompt.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/completion/CompletePrompt.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Target;
 
 import org.mcp_java.server.Cancellation;
 import org.mcp_java.server.McpConnection;
+import org.mcp_java.server.RequestId;
 import org.mcp_java.server.progress.Progress;
 import org.mcp_java.server.prompts.Prompt;
 
@@ -41,6 +42,7 @@ import org.mcp_java.server.prompts.Prompt;
  * {@code -parameters} option. The name must match the name of one of the arguments of the related prompt.
  * <li>{@link CompletionContext} - to access values already chosen for other arguments
  * <li>{@link McpConnection} - to access information about the MCP connection
+ * <li>{@link RequestId} - to access the request ID
  * <li>{@link Cancellation} - to allow processing to be stopped if the client cancels the tool call
  * <li>{@link Progress} - to send progress reports back to the client
  * <li>Implementations may define additional types that can be used as parameters

--- a/mcp-server-api/src/main/java/org/mcp_java/server/completion/CompleteResourceTemplate.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/completion/CompleteResourceTemplate.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Target;
 
 import org.mcp_java.server.Cancellation;
 import org.mcp_java.server.McpConnection;
+import org.mcp_java.server.RequestId;
 import org.mcp_java.server.progress.Progress;
 import org.mcp_java.server.resources.ResourceTemplate;
 
@@ -41,6 +42,7 @@ import org.mcp_java.server.resources.ResourceTemplate;
  * {@code -parameters} option. The name must match the name of one of the arguments of the related resource template.
  * <li>{@link CompletionContext} - to access values already chosen for other arguments
  * <li>{@link McpConnection} - to access information about the MCP connection
+ * <li>{@link RequestId} - to access the request ID
  * <li>{@link Cancellation} - to allow processing to be stopped if the client cancels the tool call
  * <li>{@link Progress} - to send progress reports back to the client
  * <li>Implementations may define additional types that can be used as parameters

--- a/mcp-server-api/src/main/java/org/mcp_java/server/prompts/Prompt.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/prompts/Prompt.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Target;
 
 import org.mcp_java.server.Cancellation;
 import org.mcp_java.server.McpConnection;
+import org.mcp_java.server.RequestId;
 import org.mcp_java.server.progress.Progress;
 
 /**
@@ -37,6 +38,7 @@ import org.mcp_java.server.progress.Progress;
  * attribute set, unless the code was compiled with the {@code -parameters} option.
  * {@code PromptArg} also allows other properties of the argument to be configured.
  * <li>{@link McpConnection} - to access information about the MCP connection
+ * <li>{@link RequestId} - to access the request ID
  * <li>{@link Cancellation} - to allow processing to be stopped if the client cancels the prompt request
  * <li>{@link Progress} - to send progress reports back to the client
  * <li>Implementations may define additional types that can be used as parameters

--- a/mcp-server-api/src/main/java/org/mcp_java/server/resources/Resource.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/resources/Resource.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Target;
 
 import org.mcp_java.server.Cancellation;
 import org.mcp_java.server.McpConnection;
+import org.mcp_java.server.RequestId;
 import org.mcp_java.server.Role;
 import org.mcp_java.server.progress.Progress;
 
@@ -34,6 +35,7 @@ import org.mcp_java.server.progress.Progress;
  * Resource methods may have parameters of the following types:
  * <ul>
  * <li>{@link McpConnection} - to access information about the MCP connection
+ * <li>{@link RequestId} - to access the request ID
  * <li>{@link Cancellation} - to allow processing to be stopped if the client cancels the resource fetch request
  * <li>{@link Progress} - to send progress reports back to the client
  * <li>Implementations may define additional types that can be used as parameters

--- a/mcp-server-api/src/main/java/org/mcp_java/server/resources/ResourceTemplate.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/resources/ResourceTemplate.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Target;
 
 import org.mcp_java.server.Cancellation;
 import org.mcp_java.server.McpConnection;
+import org.mcp_java.server.RequestId;
 import org.mcp_java.server.Role;
 import org.mcp_java.server.progress.Progress;
 
@@ -38,6 +39,7 @@ import org.mcp_java.server.progress.Progress;
  * attribute set, unless the code was compiled with the {@code -parameters} option.
  * {@code ResourceTemplateArg} also allows other properties of the argument to be configured.
  * <li>{@link McpConnection} - to access information about the MCP connection
+ * <li>{@link RequestId} - to access the request ID
  * <li>{@link Cancellation} - to allow processing to be stopped if the client cancels the tool call
  * <li>{@link Progress} - to send progress reports back to the client
  * <li>Implementations may define additional types that can be used as parameters

--- a/mcp-server-api/src/main/java/org/mcp_java/server/tools/Tool.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/tools/Tool.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Target;
 
 import org.mcp_java.server.Cancellation;
 import org.mcp_java.server.McpConnection;
+import org.mcp_java.server.RequestId;
 import org.mcp_java.server.content.ContentBlock;
 import org.mcp_java.server.progress.Progress;
 
@@ -39,6 +40,7 @@ import org.mcp_java.server.progress.Progress;
  * Tool methods may have parameters of the following types:
  * <ul>
  * <li>{@link McpConnection} - to access information about the MCP connection
+ * <li>{@link RequestId} - to access the request ID
  * <li>{@link Cancellation} - to allow processing to be stopped if the client cancels the tool call
  * <li>{@link Progress} - to send progress reports back to the client
  * <li>Implementations may define additional types that can be used as parameters


### PR DESCRIPTION
Fixes #47

In contrast to the `RequestId` classes in quarkus and Open Liberty, I chose not to include an `asInteger` method as it's likely to be unsafe to call in most circumstances.

If the user really wants that value, they can easily retrieve it themselves (with the caveat that a JSON number is not required to fit in a java `int` and the conversion may result in a negative number)

```java
if (requestId.value() instanceof Number n) {
    return n.intValue();
}
```

I think the most likely use of this interface by users is for observability or debugging, so I specified `toString` such that `"id": 3` and `"id": "3"` result in different string values.

`hashCode` and `equals` are specified so that users can safely use a `RequestId` as the key in a map.