### PR TITLE
Make McpServer just bind a named configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,12 @@ mvn test
 Here's a simple example of using the annotations:
 
 ```java
-import org.mcp_java.server.McpServer;
-import org.mcp_java.server.tools.Tool;
-import org.mcp_java.server.tools.ToolArg;
-import org.mcp_java.server.resources.Resource;
 import org.mcp_java.server.prompts.Prompt;
 import org.mcp_java.server.prompts.PromptArg;
+import org.mcp_java.server.resources.Resource;
+import org.mcp_java.server.tools.Tool;
+import org.mcp_java.server.tools.ToolArg;
 
-@McpServer(name = "my-server", description = "Example MCP server")
 public class MyMcpServer {
 
     @Tool(

--- a/mcp-server-api/src/main/java/org/mcp_java/server/McpServer.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/McpServer.java
@@ -25,13 +25,8 @@ import java.lang.annotation.Target;
 /**
  * Binds features (tools, prompts, resources) to a named MCP server configuration.
  * <p>
- * Features can be bound to multiple server configurations by declaring this annotation multiple times.
- * <p>
- * When declared on a class, all feature methods that do not declare this annotation
- * share the specified server configurations.
- * <p>
- * When declared on a method, it overrides any class-level server binding for that
- * specific feature.
+ * A feature can be bound to multiple server configurations. The set of bindings includes all values
+ * declared on the feature method and all values defined on the declaring class of the feature.
  * <p>
  * How MCP server configurations are declared and specified is implementation dependent.
  * It's expected that implementations will provide some way of configuring the name,

--- a/mcp-server-api/src/main/java/org/mcp_java/server/McpServer.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/McpServer.java
@@ -17,33 +17,35 @@ package org.mcp_java.server;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Binds features (tools, prompts, resources) to a specific MCP server configuration.
+ * Binds features (tools, prompts, resources) to a named MCP server configuration.
+ * <p>
+ * Features can be bound to multiple server configurations by declaring this annotation multiple times.
  * <p>
  * When declared on a class, all feature methods that do not declare this annotation
- * share the specified server configuration.
- * </p>
+ * share the specified server configurations.
  * <p>
  * When declared on a method, it overrides any class-level server binding for that
  * specific feature.
- * </p>
  * <p>
- * Classes annotated with {@code @McpServer} will be scanned for MCP feature annotations
- * by framework implementations.
- * </p>
+ * How MCP server configurations are declared and specified is implementation dependent.
+ * It's expected that implementations will provide some way of configuring the name,
+ * description and path of each MCP server configuration.
  *
  * @see org.mcp_java.server.tools.Tool
  * @see org.mcp_java.server.prompts.Prompt
  * @see org.mcp_java.server.resources.Resource
  * @see org.mcp_java.server.resources.ResourceTemplate
  */
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(McpServer.McpServers.class)
 public @interface McpServer {
 
     /**
@@ -52,41 +54,21 @@ public @interface McpServer {
     String DEFAULT = "<default>";
 
     /**
-     * The name of the server.
+     * The name of the server configuration the annotated features are bound to.
      * <p>
-     * This is an alias for {@link #name()}. If both are specified, {@code value()} takes precedence.
-     * </p>
-     * <p>
-     * If not specified, a name will be derived from the class name or framework configuration,
-     * or {@link #DEFAULT} will be used.
-     * </p>
+     * If not specified, they will be linked to the default configuration.
      *
-     * @return the server name
+     * @return the server configuration name
      */
     String value() default DEFAULT;
-
+    
     /**
-     * The name of the server.
-     * <p>
-     * If not specified, a name will be derived from the class name or
-     * framework configuration, or {@link #DEFAULT} will be used.
-     * </p>
-     *
-     * @return the server name
+     * Container annotation for {@link McpServer}
      */
-    String name() default "";
-
-    /**
-     * A description of what this server provides.
-     *
-     * @return the server description
-     */
-    String description() default "";
-
-    /**
-     * The version of this server.
-     *
-     * @return the server version
-     */
-    String version() default "";
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @interface McpServers {
+        McpServer[] value();
+    }
 }

--- a/mcp-server-api/src/test/java/org/mcp_java/server/test/MyMcpServer.java
+++ b/mcp-server-api/src/test/java/org/mcp_java/server/test/MyMcpServer.java
@@ -15,17 +15,15 @@
  */
 package org.mcp_java.server.test;
 
-import org.mcp_java.server.McpServer;
-import org.mcp_java.server.tools.Tool;
-import org.mcp_java.server.tools.ToolArg;
-import org.mcp_java.server.resources.Resource;
 import org.mcp_java.server.prompts.Prompt;
 import org.mcp_java.server.prompts.PromptArg;
+import org.mcp_java.server.resources.Resource;
+import org.mcp_java.server.tools.Tool;
+import org.mcp_java.server.tools.ToolArg;
 
 /**
  * Example code from README
  */
-@McpServer(name = "my-server", description = "Example MCP server")
 public class MyMcpServer {
 
     @Tool(


### PR DESCRIPTION
Remove the other methods from McpServer and just have it bind a feature to a named configuration.

Also make it repeatable so a feature can be bound to multiple configurations.

Also remove the requirement to scan all classes with this annotation for features.

This PR specifies it the same way as quarkiverse/quarkus-mcp-server#667, where a feature is bound to all configurations referenced by annotations on the class and on the method.

Fixes #25