### PR TITLE
Make feature names only unique per server config

### DIFF
--- a/mcp-server-api/src/main/java/org/mcp_java/server/prompts/Prompt.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/prompts/Prompt.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Target;
 
 import org.mcp_java.server.Cancellation;
 import org.mcp_java.server.McpRequest;
+import org.mcp_java.server.McpServer;
 import org.mcp_java.server.Role;
 import org.mcp_java.server.progress.Progress;
 
@@ -71,8 +72,9 @@ public @interface Prompt {
     /**
      * The unique name of the prompt.
      * <p>
-     * Each prompt must have a unique name. This is intended for programmatic or logical use,
-     * but may be used for UI display as a fallback if {@link #title()} is not present.
+     * Each prompt bound to the same {@linkplain McpServer MCP server configuration} must have a unique name.
+     * This is intended for programmatic or logical use, but may be used for UI display as a fallback if
+     * {@link #title()} is not present.
      * </p>
      * <p>
      * By default, the name is derived from the annotated method name.

--- a/mcp-server-api/src/main/java/org/mcp_java/server/prompts/PromptArg.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/prompts/PromptArg.java
@@ -48,9 +48,10 @@ public @interface PromptArg {
     /**
      * The name of the argument.
      * <p>
+     * Each argument to a prompt must have a unique name.
+     * <p>
      * By default, the parameter name from the method signature will be used
      * (requires compilation with the {@code -parameters} flag).
-     * </p>
      *
      * @return the argument name
      */

--- a/mcp-server-api/src/main/java/org/mcp_java/server/resources/ResourceTemplate.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/resources/ResourceTemplate.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Target;
 
 import org.mcp_java.server.Cancellation;
 import org.mcp_java.server.McpRequest;
+import org.mcp_java.server.McpServer;
 import org.mcp_java.server.Role;
 import org.mcp_java.server.progress.Progress;
 
@@ -83,9 +84,9 @@ public @interface ResourceTemplate {
     /**
      * The unique name of the resource template.
      * <p>
-     * Each resource template must have a unique name. This is intended for programmatic or logical
-     * use,
-     * but may be used for UI display as a fallback if {@link #title()} is not present.
+     * Each resource template bound to the same {@linkplain McpServer MCP server configuration} must have a unique name.
+     * This is intended for programmatic or logical use, but may be used for UI display as a fallback if
+     * {@link #title()} is not present.
      * </p>
      * <p>
      * By default, the name is derived from the annotated method name.

--- a/mcp-server-api/src/main/java/org/mcp_java/server/resources/ResourceTemplateArg.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/resources/ResourceTemplateArg.java
@@ -43,6 +43,9 @@ public @interface ResourceTemplateArg {
     /**
      * The name of the URI template variable.
      * <p>
+     * Each argument to a resource template must have a unique name and must match one of the variables
+     * included in the {@link ResourceTemplate#uriTemplate() uriTemplate}.
+     * <p>
      * By default, the parameter name from the method signature will be used
      * (requires compilation with the {@code -parameters} flag).
      * </p>

--- a/mcp-server-api/src/main/java/org/mcp_java/server/tools/Tool.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/tools/Tool.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Target;
 
 import org.mcp_java.server.Cancellation;
 import org.mcp_java.server.McpRequest;
+import org.mcp_java.server.McpServer;
 import org.mcp_java.server.content.ContentBlock;
 import org.mcp_java.server.progress.Progress;
 
@@ -83,8 +84,9 @@ public @interface Tool {
     /**
      * The unique name of the tool.
      * <p>
-     * Each tool must have a unique name. This is intended for programmatic or logical use,
-     * but may be used for UI display as a fallback if {@link #title()} is not present.
+     * Each tool bound to the same {@linkplain McpServer MCP server configuration} must have a unique name.
+     * This is intended for programmatic or logical use, but may be used for UI display as a fallback if
+     * {@link #title()} is not present.
      * </p>
      * <p>
      * By default, the name is derived from the annotated method name.

--- a/mcp-server-api/src/main/java/org/mcp_java/server/tools/ToolArg.java
+++ b/mcp-server-api/src/main/java/org/mcp_java/server/tools/ToolArg.java
@@ -51,9 +51,10 @@ public @interface ToolArg {
     /**
      * The name of the parameter as it appears in the tool's JSON Schema.
      * <p>
+     * Each argument to a tool must have a unique name.
+     * <p>
      * By default, the parameter name from the method signature will be used
      * (requires compilation with the {@code -parameters} flag).
-     * </p>
      *
      * @return the parameter name
      */


### PR DESCRIPTION
Tools, Prompts and ResourceTemplates are referenced by name in the protocol so we require them to have unique names.

However, since a different server configuration represents a different MCP server, the uniqueness constraint is only within server configurations, not across the whole application.

Also document uniqueness requirements of arg names

As suggested by @mkouba in #54 