### PR TITLE
Minor fixups

### DIFF
--- a/mcp-server-api/pom.xml
+++ b/mcp-server-api/pom.xml
@@ -22,15 +22,5 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/mcp-server-api/src/main/java/org/mcpjava/server/resources/ResourceTemplate.java
+++ b/mcp-server-api/src/main/java/org/mcpjava/server/resources/ResourceTemplate.java
@@ -35,7 +35,7 @@ import org.mcpjava.server.progress.Progress;
  * Resource template methods may have parameters of the following types:
  * <ul>
  * <li>{@link String} - the method must have one {@code String} parameter for each variable in the {@link #uriTemplate uriTemplate}.
- * In most cases these parameters must be annotated with{@link ResourceTemplateArg} with the {@link ResourceTemplateArg#name() name}
+ * In most cases these parameters must be annotated with {@link ResourceTemplateArg} with the {@link ResourceTemplateArg#name() name}
  * attribute set, unless the code was compiled with the {@code -parameters} option.
  * {@code ResourceTemplateArg} also allows other properties of the argument to be configured.
  * <li>{@link McpRequest} - to access information about the request

--- a/mcp-server-api/src/main/javadoc/overview.html
+++ b/mcp-server-api/src/main/javadoc/overview.html
@@ -23,16 +23,6 @@ limitations under the License.
         implemented by any Java-based MCP server framework.
     </p>
 
-    <h1>Core APIs</h1>
-    <ul>
-        <li>{@link org.mcpjava.server.Cancellation} - Request cancellation handling</li>
-        <li>{@link org.mcpjava.server.ContentEncoder} - Custom content encoding</li>
-        <li>{@link org.mcpjava.server.McpException} - Base MCP exception</li>
-        <li>{@link org.mcpjava.server.McpRequest} - Request metadata</li>
-        <li>{@link org.mcpjava.server.progress.Progress} - Progress reporting for long-running
-            operations</li>
-    </ul>
-
     <h1>Defining server features</h1>
     <ul>
         <li>{@link org.mcpjava.server.prompts.Prompt} - Define MCP prompts</li>
@@ -43,6 +33,16 @@ limitations under the License.
             arguments</li>
         <li>{@link org.mcpjava.server.completion.CompleteResourceTemplate} - Provide completion for MCP
             resource template arguments</li>
+    </ul>
+
+    <h1>Common APIs</h1>
+    <ul>
+        <li>{@link org.mcpjava.server.Cancellation} - Request cancellation handling</li>
+        <li>{@link org.mcpjava.server.ContentEncoder} - Custom content encoding</li>
+        <li>{@link org.mcpjava.server.McpException} - Base MCP exception</li>
+        <li>{@link org.mcpjava.server.McpRequest} - Request metadata</li>
+        <li>{@link org.mcpjava.server.progress.Progress} - Progress reporting for long-running
+            operations</li>
     </ul>
 
     <h1>Framework-Agnostic Design</h1>
@@ -57,7 +57,7 @@ limitations under the License.
     </ul>
 
     @see <a href="https://modelcontextprotocol.io">Model Context Protocol</a>
-    @see <a href="https://spec.modelcontextprotocol.io">MCP Specification</a>
+    @see <a href="https://modelcontextprotocol.io/specification/">MCP Specification</a>
 </body>
 
 </html>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Java MCP Annotations</name>
     <description>Framework-agnostic Java library for implementing Model Context Protocol (MCP) servers and clients</description>
-    <url>https://github.com/clement/java-mcp-annotations</url>
+    <url>https://github.com/mcp-java/java-mcp-annotations</url>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,6 @@
 
         <!-- Dependency versions -->
         <junit.version>5.10.2</junit.version>
-        <assertj.version>3.25.3</assertj.version>
-        <mockito.version>5.11.0</mockito.version>
 
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
@@ -75,18 +73,6 @@
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
                 <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>${assertj.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <scm>
         <connection>scm:git:git@github.com:mcp-java/java-mcp-annotations.git</connection>
         <developerConnection>scm:git:git@github.com:mcp-java/java-mcp-annotations.git</developerConnection>
-        <tag>1.0.0-Beta1</tag>
+        <tag>main</tag>
         <url>https://github.com/mcp-java/java-mcp-annotations</url>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,16 +47,16 @@
         <maven.compiler.release>17</maven.compiler.release>
 
         <!-- Dependency versions -->
-        <junit.version>5.10.2</junit.version>
+        <junit.version>5.14.4</junit.version>
 
         <!-- Plugin versions -->
-        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
         <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Apply a few minor fixes to Javadoc and metadata:

- Rearrange the Javadoc in the overview to put the main annotations first and de-emphasize the supporting APIs
- Fix overview link to the MCP spec
- Correct the project URL in the pom
- Correct the development branch in the pom
- Remove unused test dependencies
- Bump remaining dependency versions