### PR TITLE
Allow multiple audiences in resource annotations

### DIFF
--- a/mcp-server-api/src/main/java/org/mcpjava/server/resources/Resource.java
+++ b/mcp-server-api/src/main/java/org/mcpjava/server/resources/Resource.java
@@ -151,9 +151,9 @@ public @interface Resource {
         /**
          * The intended audience for this resource.
          *
-         * @return the intended audience role
+         * @return the intended audience roles
          */
-        Role audience();
+        Role[] audience();
 
         /**
          * The last modification timestamp in ISO 8601 format.

--- a/mcp-server-api/src/main/java/org/mcpjava/server/resources/ResourceTemplate.java
+++ b/mcp-server-api/src/main/java/org/mcpjava/server/resources/ResourceTemplate.java
@@ -162,9 +162,9 @@ public @interface ResourceTemplate {
         /**
          * The intended audience for resources from this template.
          *
-         * @return the intended audience role
+         * @return the intended audience roles
          */
-        Role audience();
+        Role[] audience();
 
         /**
          * The last modification timestamp in ISO 8601 format.


### PR DESCRIPTION
Make audience an array of Roles for the Annotations annotation for both resources and resource templates, matching [the protocol schema](https://modelcontextprotocol.org/specification/2025-11-25/schema#annotations).

Fixes #60 