### PR TITLE
Give `Resource.Annotations` empty defaults

### DIFF
--- a/mcp-server-api/src/main/java/org/mcpjava/server/resources/Resource.java
+++ b/mcp-server-api/src/main/java/org/mcpjava/server/resources/Resource.java
@@ -136,7 +136,7 @@ public @interface Resource {
      *
      * @return the resource annotations
      */
-    Annotations annotations() default @Annotations(audience = Role.USER, lastModified = "", priority = 0.5);
+    Annotations annotations() default @Annotations;
 
     /**
      * Nested annotation for resource metadata annotations.
@@ -151,25 +151,25 @@ public @interface Resource {
         /**
          * The intended audience for this resource.
          *
-         * @return the intended audience roles
+         * @return the intended audience roles, or an empty array to indicate no value
          */
-        Role[] audience();
+        Role[] audience() default {};
 
         /**
          * The last modification timestamp in ISO 8601 format.
          *
-         * @return the last modified timestamp
+         * @return the last modified timestamp, or an empty string to indicate no value
          */
         String lastModified() default "";
 
         /**
          * The priority of this resource.
          * <p>
-         * Higher values indicate higher priority.
+         * 1.0 represents the highest priority, and 0.0 represents the lowest priority.
          * </p>
          *
-         * @return the priority value
+         * @return the priority value between 0.0 and 1.0, or -1 to indicate no value
          */
-        double priority() default 0.5;
+        double priority() default -1;
     }
 }

--- a/mcp-server-api/src/main/java/org/mcpjava/server/resources/ResourceTemplate.java
+++ b/mcp-server-api/src/main/java/org/mcpjava/server/resources/ResourceTemplate.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Target;
 import org.mcpjava.server.Cancellation;
 import org.mcpjava.server.McpRequest;
 import org.mcpjava.server.McpServer;
-import org.mcpjava.server.Role;
 import org.mcpjava.server.progress.Progress;
+import org.mcpjava.server.resources.Resource.Annotations;
 
 /**
  * Marks a method as providing dynamic MCP resources via URI templates.
@@ -148,39 +148,5 @@ public @interface ResourceTemplate {
      *
      * @return the template annotations
      */
-    Annotations annotations() default @Annotations(audience = Role.USER, lastModified = "", priority = 0.5);
-
-    /**
-     * Nested annotation for resource template metadata annotations.
-     * <p>
-     * These provide hints to clients about resources from this template.
-     * </p>
-     */
-    @Target(ElementType.ANNOTATION_TYPE)
-    @Retention(RetentionPolicy.RUNTIME)
-    @interface Annotations {
-        /**
-         * The intended audience for resources from this template.
-         *
-         * @return the intended audience roles
-         */
-        Role[] audience();
-
-        /**
-         * The last modification timestamp in ISO 8601 format.
-         *
-         * @return the last modified timestamp
-         */
-        String lastModified() default "";
-
-        /**
-         * The priority of resources from this template.
-         * <p>
-         * Higher values indicate higher priority.
-         * </p>
-         *
-         * @return the priority value
-         */
-        double priority() default 0.5;
-    }
+    Annotations annotations() default @Annotations;
 }


### PR DESCRIPTION
Give every field of `Resource.Annotations` a default which represents no value is present.

Use this as the default for resources and resource templates.

Remove `ResourceTemplate.Annotations`. Have `ResourceTemplate` use `Resource.Annotations` instead.

Fixes #63